### PR TITLE
capitalize first letter of person provider ids

### DIFF
--- a/NfoMetadata/Parsers/BaseNfoParser.cs
+++ b/NfoMetadata/Parsers/BaseNfoParser.cs
@@ -1146,6 +1146,9 @@ namespace NfoMetadata.Parsers
                                 {
                                     if (!string.IsNullOrWhiteSpace(val))
                                     {
+                                        char[] a = readerName.ToCharArray();
+                                        a[0] = char.ToUpper(a[0]);
+                                        readerName = new string(a);
                                         providerIds[readerName] = val;
                                     }
                                 }


### PR DESCRIPTION
Although Emby reads lowercase person provider ids just fine and generates proper links in the person details screen of the web app, the metadata editor doesn't show any id because it refers to data-providerkey Imdb, Tmdb and Tvdb.
Of course it would be better if all provider ids were lowercase everywhere - Database, c# code and javascript. Especially writing to nfo, which is case sensitive and Emby is the only app that writes xml elements with a starting uppercase letter. But i guess that's not that easy, because of old data.