### PR TITLE
Write lowercase unique provider ids

### DIFF
--- a/NfoMetadata/Savers/BaseNfoSaver.cs
+++ b/NfoMetadata/Savers/BaseNfoSaver.cs
@@ -852,7 +852,7 @@ namespace NfoMetadata.Savers
             {
                 foreach (var providerIdPair in item.ProviderIds)
                 {
-                    var providerKey = providerIdPair.Key;
+                    var providerKey = providerIdPair.Key.ToLowerInvariant();
                     var providerId = providerIdPair.Value;
 
                     if (string.IsNullOrEmpty(providerId))


### PR DESCRIPTION
All xml elements and attributes should be lowercase for Kodi. Only Emby writes provider ids with capitalized first letters.