### PR TITLE
Avoid running into Exceptions unnecessarily

### DIFF
--- a/NfoMetadata/Helpers.cs
+++ b/NfoMetadata/Helpers.cs
@@ -14,6 +14,11 @@ namespace NfoMetadata
     {
         public static FileSystemMetadata GetFileInfo(IDirectoryService directoryService, string directory, string filename)
         {
+            if (directory == null || filename == null)
+            {
+                return null;
+            }
+
             try
             {
                 var entries = directoryService.GetFileSystemEntries(directory);


### PR DESCRIPTION
When either filename or directory is null, there's no point in calling into the DirectoryService